### PR TITLE
CA certificates 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV GOOS=linux
 ENV GOARCH=amd64
 
 # [x509: certificate signed by unknown authority를 해결하기 위해서 CA certificates 추가](https://velog.io/@byron1st/x.509-certificate-signed-by-unknown-authority)
-RUN apt-get update && apt-get upgrade && apt-get add --no-cache ca-certificates
+RUN apt-get update && apt-get -y upgrade && apt-get add --no-cache ca-certificates
 
 WORKDIR /build
 COPY ./go.mod ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV GOOS=linux
 ENV GOARCH=amd64
 
 # [x509: certificate signed by unknown authority를 해결하기 위해서 CA certificates 추가](https://velog.io/@byron1st/x.509-certificate-signed-by-unknown-authority)
-RUN apk update && apk upgrade && apk add --no-cache ca-certificates
+RUN apt-get update && apt-get upgrade && apt-get add --no-cache ca-certificates
 
 WORKDIR /build
 COPY ./go.mod ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV GOOS=linux
 ENV GOARCH=amd64
 
 # [x509: certificate signed by unknown authority를 해결하기 위해서 CA certificates 추가](https://velog.io/@byron1st/x.509-certificate-signed-by-unknown-authority)
-RUN apt-get update && apt-get -y upgrade && apt-get add --no-cache ca-certificates
+RUN apt-get update && apt-get -y upgrade && apt-get install ca-certificates
 
 WORKDIR /build
 COPY ./go.mod ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
 
+# [x509: certificate signed by unknown authority를 해결하기 위해서 CA certificates 추가](https://velog.io/@byron1st/x.509-certificate-signed-by-unknown-authority)
+RUN apk update && apk upgrade && apk add --no-cache ca-certificates
+
 WORKDIR /build
 COPY ./go.mod ./
 COPY ./go.sum ./
@@ -25,6 +28,7 @@ ENV GO_ENV=production
 
 COPY --from=golang-builder /dist/main ./
 COPY --from=golang-builder /dist/config.prod.json ./configs/config.prod.json
+COPY --from=golang-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 EXPOSE 8080
 

--- a/internal/pkg/project/project.go
+++ b/internal/pkg/project/project.go
@@ -2,5 +2,5 @@ package project
 
 const (
 	AppName    string = "oauth-server"
-	AppVersion string = "0.2.1"
+	AppVersion string = "0.2.2"
 )


### PR DESCRIPTION
1. kakao oauth 시도 시 `x509: certificate signed by unknown authority` 에러가 발생하였습니다.
1. 트러블 슈팅 결과 docker image에서 기본적으로 `CA certificates` 가 추가되어있지 않아서 발생한 문제입니다.
1. docker image build 시 `CA certificates` 를 추가하여 해결하였습니다.