### PR TITLE
k8s replicas 2로 변경

### DIFF
--- a/k8s/prod.yaml
+++ b/k8s/prod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: oauth-server
   namespace: prod
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: oauth-server

--- a/k8s/qa.yaml
+++ b/k8s/qa.yaml
@@ -4,7 +4,7 @@ metadata:
   name: oauth-server
   namespace: qa
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: oauth-server


### PR DESCRIPTION
# Feature

1. `storage-service` 가 실 환경인 k8s에 배포 됨에 따라 클러스터의 컴퓨팅 파워가 부족하여 k8s scheduler 부드럽게 동작하지 못하고 있습니다.
1. 이에 따라 `belf` 에서 사용하는 서비스의 replicas을 `3` 에서 `2` 으로 변경하도록 합니다.

