### PR TITLE
사용자 아바타 사진 업로드/삭제 API 추가

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -155,7 +155,7 @@ var doc = `{
             "post": {
                 "description": "사용자 프로필 사진을 업로드 합니다.",
                 "consumes": [
-                    "application/json"
+                    "multipart/form-data"
                 ],
                 "produces": [
                     "application/json"
@@ -171,8 +171,38 @@ var doc = `{
                         "name": "Authorization",
                         "in": "header",
                         "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "프로필 사진",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
                     }
-                ]
+                ],
+                "responses": {
+                    "201": {
+                        "description": ""
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    }
+                }
             }
         },
         "/users/login": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -153,7 +153,7 @@ var doc = `{
         },
         "/users/avatar": {
             "post": {
-                "description": "사용자 프로필 사진을 업로드 합니다.",
+                "description": "사용자 아바타(프로필) 사진을 업로드 합니다.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -163,7 +163,7 @@ var doc = `{
                 "tags": [
                     "User"
                 ],
-                "summary": "사용자 프로필 사진 업로드",
+                "summary": "사용자 아바타 사진 업로드",
                 "parameters": [
                     {
                         "type": "string",
@@ -174,7 +174,7 @@ var doc = `{
                     },
                     {
                         "type": "file",
-                        "description": "프로필 사진",
+                        "description": "아바타 사진",
                         "name": "file",
                         "in": "formData",
                         "required": true
@@ -205,7 +205,7 @@ var doc = `{
                 }
             },
             "delete": {
-                "description": "사용자 프로필 사진을 삭제합니다.",
+                "description": "사용자 아바타(프로필) 사진을 삭제합니다.",
                 "consumes": [
                     "application/json"
                 ],
@@ -215,7 +215,7 @@ var doc = `{
                 "tags": [
                     "User"
                 ],
-                "summary": "사용자 프로필 사진 삭제",
+                "summary": "사용자 아바타 사진 삭제",
                 "parameters": [
                     {
                         "type": "string",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -151,6 +151,30 @@ var doc = `{
                 }
             }
         },
+        "/users/avatar": {
+            "post": {
+                "description": "사용자 프로필 사진을 업로드 합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "사용자 프로필 사진 업로드",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer {AccessToken}",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    }
+                ]
+            }
+        },
         "/users/login": {
             "post": {
                 "description": "로그인을 성공 시 JWT token이 발급됩니다.",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -228,6 +228,18 @@ var doc = `{
                 "responses": {
                     "204": {
                         "description": ""
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
                     }
                 }
             }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -203,6 +203,33 @@ var doc = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "사용자 프로필 사진을 삭제합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "사용자 프로필 사진 삭제",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer {AccessToken}",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": ""
+                    }
+                }
             }
         },
         "/users/login": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -131,6 +131,30 @@
                 }
             }
         },
+        "/users/avatar": {
+            "post": {
+                "description": "사용자 프로필 사진을 업로드 합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "사용자 프로필 사진 업로드",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer {AccessToken}",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    }
+                ]
+            }
+        },
         "/users/login": {
             "post": {
                 "description": "로그인을 성공 시 JWT token이 발급됩니다.",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -208,6 +208,18 @@
                 "responses": {
                     "204": {
                         "description": ""
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
                     }
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -135,7 +135,7 @@
             "post": {
                 "description": "사용자 프로필 사진을 업로드 합니다.",
                 "consumes": [
-                    "application/json"
+                    "multipart/form-data"
                 ],
                 "produces": [
                     "application/json"
@@ -151,8 +151,38 @@
                         "name": "Authorization",
                         "in": "header",
                         "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "프로필 사진",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
                     }
-                ]
+                ],
+                "responses": {
+                    "201": {
+                        "description": ""
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    }
+                }
             }
         },
         "/users/login": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -133,7 +133,7 @@
         },
         "/users/avatar": {
             "post": {
-                "description": "사용자 프로필 사진을 업로드 합니다.",
+                "description": "사용자 아바타(프로필) 사진을 업로드 합니다.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -143,7 +143,7 @@
                 "tags": [
                     "User"
                 ],
-                "summary": "사용자 프로필 사진 업로드",
+                "summary": "사용자 아바타 사진 업로드",
                 "parameters": [
                     {
                         "type": "string",
@@ -154,7 +154,7 @@
                     },
                     {
                         "type": "file",
-                        "description": "프로필 사진",
+                        "description": "아바타 사진",
                         "name": "file",
                         "in": "formData",
                         "required": true
@@ -185,7 +185,7 @@
                 }
             },
             "delete": {
-                "description": "사용자 프로필 사진을 삭제합니다.",
+                "description": "사용자 아바타(프로필) 사진을 삭제합니다.",
                 "consumes": [
                     "application/json"
                 ],
@@ -195,7 +195,7 @@
                 "tags": [
                     "User"
                 ],
-                "summary": "사용자 프로필 사진 삭제",
+                "summary": "사용자 아바타 사진 삭제",
                 "parameters": [
                     {
                         "type": "string",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -183,6 +183,33 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "사용자 프로필 사진을 삭제합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "사용자 프로필 사진 삭제",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer {AccessToken}",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": ""
+                    }
+                }
             }
         },
         "/users/login": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -243,7 +243,7 @@ paths:
     delete:
       consumes:
       - application/json
-      description: 사용자 프로필 사진을 삭제합니다.
+      description: 사용자 아바타(프로필) 사진을 삭제합니다.
       parameters:
       - description: Bearer {AccessToken}
         in: header
@@ -263,20 +263,20 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/models.ErrResponse'
-      summary: 사용자 프로필 사진 삭제
+      summary: 사용자 아바타 사진 삭제
       tags:
       - User
     post:
       consumes:
       - multipart/form-data
-      description: 사용자 프로필 사진을 업로드 합니다.
+      description: 사용자 아바타(프로필) 사진을 업로드 합니다.
       parameters:
       - description: Bearer {AccessToken}
         in: header
         name: Authorization
         required: true
         type: string
-      - description: 프로필 사진
+      - description: 아바타 사진
         in: formData
         name: file
         required: true
@@ -298,7 +298,7 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/models.ErrResponse'
-      summary: 사용자 프로필 사진 업로드
+      summary: 사용자 아바타 사진 업로드
       tags:
       - User
   /users/login:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -255,6 +255,14 @@ paths:
       responses:
         "204":
           description: ""
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrResponse'
       summary: 사용자 프로필 사진 삭제
       tags:
       - User

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -240,6 +240,24 @@ paths:
       tags:
       - User
   /users/avatar:
+    delete:
+      consumes:
+      - application/json
+      description: 사용자 프로필 사진을 삭제합니다.
+      parameters:
+      - description: Bearer {AccessToken}
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: ""
+      summary: 사용자 프로필 사진 삭제
+      tags:
+      - User
     post:
       consumes:
       - multipart/form-data

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -242,7 +242,7 @@ paths:
   /users/avatar:
     post:
       consumes:
-      - application/json
+      - multipart/form-data
       description: 사용자 프로필 사진을 업로드 합니다.
       parameters:
       - description: Bearer {AccessToken}
@@ -250,8 +250,28 @@ paths:
         name: Authorization
         required: true
         type: string
+      - description: 프로필 사진
+        in: formData
+        name: file
+        required: true
+        type: file
       produces:
       - application/json
+      responses:
+        "201":
+          description: ""
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrResponse'
       summary: 사용자 프로필 사진 업로드
       tags:
       - User

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -239,6 +239,22 @@ paths:
       summary: Email로 사용자 정보 조회
       tags:
       - User
+  /users/avatar:
+    post:
+      consumes:
+      - application/json
+      description: 사용자 프로필 사진을 업로드 합니다.
+      parameters:
+      - description: Bearer {AccessToken}
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      produces:
+      - application/json
+      summary: 사용자 프로필 사진 업로드
+      tags:
+      - User
   /users/login:
     post:
       consumes:

--- a/internal/app/handlers/users.go
+++ b/internal/app/handlers/users.go
@@ -528,6 +528,8 @@ func UploadAvatar(c *gin.Context) {
 // @Produce json
 // @Param Authorization header string true "Bearer {AccessToken}"
 // @Success 204
+// @Failure 401 {object} models.ErrResponse
+// @Failure 500 {object} models.ErrResponse
 // @Router /users/avatar [delete]
 func DeleteAvatar(c *gin.Context) {
 	au, err := auth.ExtractTokenMetadata(c.Request)

--- a/internal/app/handlers/users.go
+++ b/internal/app/handlers/users.go
@@ -530,5 +530,20 @@ func UploadAvatar(c *gin.Context) {
 // @Success 204
 // @Router /users/avatar [delete]
 func DeleteAvatar(c *gin.Context) {
+	au, err := auth.ExtractTokenMetadata(c.Request)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, models.ErrResponse{
+			Message: err.Error(),
+		})
+		return
+	}
+
+	if err := orm.Client.Model(&entitys.User{}).Where("id = ?", au.UserId).Update("AvatarImage", nil).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, models.ErrResponse{
+			Message: err.Error(),
+		})
+		return
+	}
+
 	c.Status(http.StatusNoContent)
 }

--- a/internal/app/handlers/users.go
+++ b/internal/app/handlers/users.go
@@ -520,3 +520,15 @@ func UploadAvatar(c *gin.Context) {
 
 	c.Status(http.StatusCreated)
 }
+
+// @Summary 사용자 프로필 사진 삭제
+// @Description 사용자 프로필 사진을 삭제합니다.
+// @Tags User
+// @Accept json
+// @Produce json
+// @Param Authorization header string true "Bearer {AccessToken}"
+// @Success 204
+// @Router /users/avatar [delete]
+func DeleteAvatar(c *gin.Context) {
+	c.Status(http.StatusNoContent)
+}

--- a/internal/app/handlers/users.go
+++ b/internal/app/handlers/users.go
@@ -465,13 +465,13 @@ func UserTokenRefresh(c *gin.Context) {
 	}
 }
 
-// @Summary 사용자 프로필 사진 업로드
-// @Description 사용자 프로필 사진을 업로드 합니다.
+// @Summary 사용자 아바타 사진 업로드
+// @Description 사용자 아바타(프로필) 사진을 업로드 합니다.
 // @Tags User
 // @Accept mpfd
 // @Produce json
 // @Param Authorization header string true "Bearer {AccessToken}"
-// @Param file formData file true "프로필 사진"
+// @Param file formData file true "아바타 사진"
 // @Success 201
 // @Failure 400 {object} models.ErrResponse
 // @Failure 401 {object} models.ErrResponse
@@ -521,8 +521,8 @@ func UploadAvatar(c *gin.Context) {
 	c.Status(http.StatusCreated)
 }
 
-// @Summary 사용자 프로필 사진 삭제
-// @Description 사용자 프로필 사진을 삭제합니다.
+// @Summary 사용자 아바타 사진 삭제
+// @Description 사용자 아바타(프로필) 사진을 삭제합니다.
 // @Tags User
 // @Accept json
 // @Produce json

--- a/internal/app/handlers/users.go
+++ b/internal/app/handlers/users.go
@@ -464,3 +464,16 @@ func UserTokenRefresh(c *gin.Context) {
 		})
 	}
 }
+
+// @Summary 사용자 프로필 사진 업로드
+// @Description 사용자 프로필 사진을 업로드 합니다.
+// @Tags User
+// @Accept json
+// @Produce json
+// @Param Authorization header string true "Bearer {AccessToken}"
+// @Router /users/avatar [post]
+func UploadAvatar(c *gin.Context) {
+	c.JSON(http.StatusOK, map[string]string{
+		"조회": "완료",
+	})
+}

--- a/internal/app/routers/router.go
+++ b/internal/app/routers/router.go
@@ -16,11 +16,14 @@ func Use(api *gin.RouterGroup) {
 		users.POST("/signup", handlers.UserSignup)
 		users.POST("/login", handlers.UserLogin)
 		users.GET("/login/kakao", handlers.UserKakaoLoginCallBack)
-		users.GET("", middlewares.TokenAuthMiddleware(), handlers.UserInfoTokenQuey)
-		users.GET(":userEmail", handlers.UserInfoEmailQuey)
 		users.POST("/logout", middlewares.TokenAuthMiddleware(), handlers.UserLogout)
+
 		users.GET("/token/valid", middlewares.TokenAuthMiddleware(), handlers.UserTokenValid)
 		users.POST("/token/refresh", handlers.UserTokenRefresh)
+
+		users.GET("", middlewares.TokenAuthMiddleware(), handlers.UserInfoTokenQuey)
+		users.GET(":userEmail", handlers.UserInfoEmailQuey)
+		users.POST("/avatar", middlewares.TokenAuthMiddleware(), handlers.UploadAvatar)
 	}
 	configs := api.Group("/configs")
 	{

--- a/internal/app/routers/router.go
+++ b/internal/app/routers/router.go
@@ -24,6 +24,7 @@ func Use(api *gin.RouterGroup) {
 		users.GET("", middlewares.TokenAuthMiddleware(), handlers.UserInfoTokenQuey)
 		users.GET(":userEmail", handlers.UserInfoEmailQuey)
 		users.POST("/avatar", middlewares.TokenAuthMiddleware(), handlers.UploadAvatar)
+		users.DELETE("/avatar", middlewares.TokenAuthMiddleware(), handlers.DeleteAvatar)
 	}
 	configs := api.Group("/configs")
 	{


### PR DESCRIPTION
# Feature

1. 사용자 아바타 사진을 업로드할 수 있는 API가 추가되었습니다.
1. 사용자 아바타 사진을 삭제할 수 있는 API가 추가되었습니다.

# Test 시나리오

1. qa 도메인에 맞는 `~/swagger/index.html` 으로 접속하여 로그인 후 아바타 사진을 업로드하는 API를 호출합니다.
2. 아바타 사진을 업로드한 사용자를 조회하여 정상적으로 `업로드` 되었는지 확인합니다.
3. 아바타 사진 삭제 API를 호출합니다.
4. 아바타 사진을 업로드한 사용자를 조회하여 정상적으로 `삭제` 되었는지 확인합니다.