### PR TITLE
회원탈퇴 API 추가, 회원가입 EndPoint 변경

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -116,7 +116,7 @@ var doc = `{
                 "tags": [
                     "User"
                 ],
-                "summary": "Token으로 사용자 정보 조회",
+                "summary": "사용자 조회",
                 "parameters": [
                     {
                         "type": "string",
@@ -141,6 +141,101 @@ var doc = `{
                     },
                     "404": {
                         "description": ""
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "사용자를 생성합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "사용자 생성 (회원가입)",
+                "parameters": [
+                    {
+                        "description": "회원가입을 위한 정보",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.UserSignUp"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/entitys.User"
+                        },
+                        "headers": {
+                            "Location": {
+                                "type": "string",
+                                "description": "/users/1"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "사용자를 삭제합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "사용자 삭제 (회원탈퇴)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer {AccessToken}",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": ""
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
                     },
                     "500": {
                         "description": "Internal Server Error",
@@ -379,64 +474,6 @@ var doc = `{
                     },
                     "401": {
                         "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/models.ErrResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/models.ErrResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/users/signup": {
-            "post": {
-                "description": "사용자를 생성합니다.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "User"
-                ],
-                "summary": "회원가입",
-                "parameters": [
-                    {
-                        "description": "회원가입을 위한 정보",
-                        "name": "data",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.UserSignUp"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/entitys.User"
-                        },
-                        "headers": {
-                            "Location": {
-                                "type": "string",
-                                "description": "/users/1"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/models.ErrResponse"
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/models.ErrResponse"
                         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -96,7 +96,7 @@
                 "tags": [
                     "User"
                 ],
-                "summary": "Token으로 사용자 정보 조회",
+                "summary": "사용자 조회",
                 "parameters": [
                     {
                         "type": "string",
@@ -121,6 +121,101 @@
                     },
                     "404": {
                         "description": ""
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "사용자를 생성합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "사용자 생성 (회원가입)",
+                "parameters": [
+                    {
+                        "description": "회원가입을 위한 정보",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.UserSignUp"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/entitys.User"
+                        },
+                        "headers": {
+                            "Location": {
+                                "type": "string",
+                                "description": "/users/1"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "사용자를 삭제합니다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "사용자 삭제 (회원탈퇴)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer {AccessToken}",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": ""
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrResponse"
+                        }
                     },
                     "500": {
                         "description": "Internal Server Error",
@@ -359,64 +454,6 @@
                     },
                     "401": {
                         "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/models.ErrResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/models.ErrResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/users/signup": {
-            "post": {
-                "description": "사용자를 생성합니다.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "User"
-                ],
-                "summary": "회원가입",
-                "parameters": [
-                    {
-                        "description": "회원가입을 위한 정보",
-                        "name": "data",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.UserSignUp"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/entitys.User"
-                        },
-                        "headers": {
-                            "Location": {
-                                "type": "string",
-                                "description": "/users/1"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/models.ErrResponse"
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/models.ErrResponse"
                         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -180,6 +180,32 @@ paths:
       tags:
       - App
   /users:
+    delete:
+      consumes:
+      - application/json
+      description: 사용자를 삭제합니다.
+      parameters:
+      - description: Bearer {AccessToken}
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: ""
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrResponse'
+      summary: 사용자 삭제 (회원탈퇴)
+      tags:
+      - User
     get:
       consumes:
       - application/json
@@ -207,7 +233,44 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/models.ErrResponse'
-      summary: Token으로 사용자 정보 조회
+      summary: 사용자 조회
+      tags:
+      - User
+    post:
+      consumes:
+      - application/json
+      description: 사용자를 생성합니다.
+      parameters:
+      - description: 회원가입을 위한 정보
+        in: body
+        name: data
+        required: true
+        schema:
+          $ref: '#/definitions/models.UserSignUp'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          headers:
+            Location:
+              description: /users/1
+              type: string
+          schema:
+            $ref: '#/definitions/entitys.User'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/models.ErrResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrResponse'
+      summary: 사용자 생성 (회원가입)
       tags:
       - User
   /users/{userEmail}:
@@ -397,44 +460,6 @@ paths:
           schema:
             $ref: '#/definitions/models.ErrResponse'
       summary: 로그아웃
-      tags:
-      - User
-  /users/signup:
-    post:
-      consumes:
-      - application/json
-      description: 사용자를 생성합니다.
-      parameters:
-      - description: 회원가입을 위한 정보
-        in: body
-        name: data
-        required: true
-        schema:
-          $ref: '#/definitions/models.UserSignUp'
-      produces:
-      - application/json
-      responses:
-        "201":
-          description: Created
-          headers:
-            Location:
-              description: /users/1
-              type: string
-          schema:
-            $ref: '#/definitions/entitys.User'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/models.ErrResponse'
-        "409":
-          description: Conflict
-          schema:
-            $ref: '#/definitions/models.ErrResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/models.ErrResponse'
-      summary: 회원가입
       tags:
       - User
   /users/token/refresh:

--- a/internal/app/handlers/users.go
+++ b/internal/app/handlers/users.go
@@ -343,8 +343,7 @@ func UserLogout(c *gin.Context) {
 		return
 	}
 
-	deleted, err := auth.DeleteAuth(au.AccessUuid)
-	if err != nil || deleted == 0 {
+	if deleted, err := auth.DeleteAuth(au.AccessUuid); err != nil || deleted == 0 {
 		c.JSON(http.StatusUnauthorized, models.ErrResponse{
 			Message: err.Error(),
 		})
@@ -584,8 +583,7 @@ func UserWithdrawal(c *gin.Context) {
 		return
 	}
 
-	deleted, err := auth.DeleteAuth(au.AccessUuid)
-	if err != nil || deleted == 0 {
+	if deleted, err := auth.DeleteAuth(au.AccessUuid); err != nil || deleted == 0 {
 		c.JSON(http.StatusUnauthorized, models.ErrResponse{
 			Message: err.Error(),
 		})

--- a/internal/app/handlers/users.go
+++ b/internal/app/handlers/users.go
@@ -561,5 +561,28 @@ func DeleteAvatar(c *gin.Context) {
 // @Failure 500 {object} models.ErrResponse
 // @Router /users [delete]
 func UserWithdrawal(c *gin.Context) {
+	au, err := auth.ExtractTokenMetadata(c.Request)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, models.ErrResponse{
+			Message: err.Error(),
+		})
+		return
+	}
+
+	// 카카오 테이블만 삭제하더라도 reference된 사용자 데이블도 cascade로 같이 삭제되지만 카카오 로그인이 아닌 회원가입의 경우 삭제되지 않기 때문에 2번의 쿼리로 사용자 데이터를 삭제하도록 합니다.
+	if err := orm.Client.Where("id = ?", au.UserId).Delete(&entitys.User{}).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, models.ErrResponse{
+			Message: err.Error(),
+		})
+		return
+	}
+
+	if err := orm.Client.Where("id = ?", au.UserId).Delete(&entitys.KakaoTalkSocial{}).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, models.ErrResponse{
+			Message: err.Error(),
+		})
+		return
+	}
+
 	c.Status(http.StatusNoContent)
 }

--- a/internal/app/handlers/users.go
+++ b/internal/app/handlers/users.go
@@ -569,14 +569,14 @@ func UserWithdrawal(c *gin.Context) {
 	}
 
 	// 카카오 테이블만 삭제하더라도 reference된 사용자 데이블도 cascade로 같이 삭제되지만 카카오 로그인이 아닌 회원가입의 경우 삭제되지 않기 때문에 2번의 쿼리로 사용자 데이터를 삭제하도록 합니다.
-	if err := orm.Client.Where("id = ?", au.UserId).Delete(&entitys.User{}).Error; err != nil {
+	if err := orm.Client.Where("email = ?", au.UserId).Delete(&entitys.User{}).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, models.ErrResponse{
 			Message: err.Error(),
 		})
 		return
 	}
 
-	if err := orm.Client.Where("id = ?", au.UserId).Delete(&entitys.KakaoTalkSocial{}).Error; err != nil {
+	if err := orm.Client.Where("email = ?", au.UserId).Delete(&entitys.KakaoTalkSocial{}).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, models.ErrResponse{
 			Message: err.Error(),
 		})

--- a/internal/app/handlers/users.go
+++ b/internal/app/handlers/users.go
@@ -21,7 +21,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// @Summary 회원가입
+// @Summary 사용자 생성 (회원가입)
 // @Description 사용자를 생성합니다.
 // @Tags User
 // @Accept json
@@ -32,7 +32,7 @@ import (
 // @Failure 400 {object} models.ErrResponse
 // @Failure 409 {object} models.ErrResponse
 // @Failure 500 {object} models.ErrResponse
-// @Router /users/signup [post]
+// @Router /users [post]
 func UserSignup(c *gin.Context) {
 	userBody := models.UserSignUp{}
 
@@ -251,7 +251,7 @@ func UserKakaoLoginCallBack(c *gin.Context) {
 	c.Redirect(http.StatusFound, redUrl)
 }
 
-// @Summary Token으로 사용자 정보 조회
+// @Summary 사용자 조회
 // @Description token 클레임에 있는 id 값으로 사용자를 조회합니다.
 // @Tags User
 // @Accept json
@@ -547,5 +547,19 @@ func DeleteAvatar(c *gin.Context) {
 		return
 	}
 
+	c.Status(http.StatusNoContent)
+}
+
+// @Summary 사용자 삭제 (회원탈퇴)
+// @Description 사용자를 삭제합니다.
+// @Tags User
+// @Accept json
+// @Produce json
+// @Param Authorization header string true "Bearer {AccessToken}"
+// @Success 204
+// @Failure 401 {object} models.ErrResponse
+// @Failure 500 {object} models.ErrResponse
+// @Router /users [delete]
+func UserWithdrawal(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }

--- a/internal/app/handlers/users.go
+++ b/internal/app/handlers/users.go
@@ -584,5 +584,13 @@ func UserWithdrawal(c *gin.Context) {
 		return
 	}
 
+	deleted, err := auth.DeleteAuth(au.AccessUuid)
+	if err != nil || deleted == 0 {
+		c.JSON(http.StatusUnauthorized, models.ErrResponse{
+			Message: err.Error(),
+		})
+		return
+	}
+
 	c.Status(http.StatusNoContent)
 }

--- a/internal/app/routers/router.go
+++ b/internal/app/routers/router.go
@@ -13,7 +13,6 @@ func Use(api *gin.RouterGroup) {
 	api.GET("/env", handlers.AppEnv)
 	users := api.Group("/users")
 	{
-		users.POST("/signup", handlers.UserSignup)
 		users.POST("/login", handlers.UserLogin)
 		users.GET("/login/kakao", handlers.UserKakaoLoginCallBack)
 		users.POST("/logout", middlewares.TokenAuthMiddleware(), handlers.UserLogout)
@@ -21,7 +20,9 @@ func Use(api *gin.RouterGroup) {
 		users.GET("/token/valid", middlewares.TokenAuthMiddleware(), handlers.UserTokenValid)
 		users.POST("/token/refresh", handlers.UserTokenRefresh)
 
+		users.POST("", handlers.UserSignup)
 		users.GET("", middlewares.TokenAuthMiddleware(), handlers.UserInfoTokenQuey)
+		users.DELETE("", middlewares.TokenAuthMiddleware(), handlers.UserWithdrawal)
 		users.GET(":userEmail", handlers.UserInfoEmailQuey)
 		users.POST("/avatar", middlewares.TokenAuthMiddleware(), handlers.UploadAvatar)
 		users.DELETE("/avatar", middlewares.TokenAuthMiddleware(), handlers.DeleteAvatar)


### PR DESCRIPTION
# Feature

1. 회원탈퇴 API가 추가되었습니다.
1. 사용자를 생성하는 API의 endpoint가 변경되었습니다.

# 테스트 방법

1. 회원탈퇴 API 호출 시 정상적으로 사용자 정보가 삭제되는지 확인합니다.
2. `froint-server` 에서 회원가입시 정상적으로 사용자가 생성되는지 확인합니다.