### PR TITLE
deprecated된 kubectl 명령어 변경, slack slack notification 메시지 표시되도록, 환경 변수 조회 API 제거

### DIFF
--- a/.github/workflows/aks-prod-deploy.yaml
+++ b/.github/workflows/aks-prod-deploy.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: create namespace
         run: |
-          kubectl create namespace ${{ env.NAMESPACE }} --dry-run -o json | kubectl apply -f -
+          kubectl create namespace ${{ env.NAMESPACE }} --dry-run=client -o json | kubectl apply -f -
 
       - name: aks apply object
         uses: Azure/k8s-deploy@v1.4
@@ -64,3 +64,4 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: ${{ github.repository }}가 ${{ env.NAMESPACE }} 환경에 배포되었습니다 🚀

--- a/.github/workflows/aks-qa-deploy.yaml
+++ b/.github/workflows/aks-qa-deploy.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: create namespace
         run: |
-          kubectl create namespace ${{ env.NAMESPACE }} --dry-run -o json | kubectl apply -f -
+          kubectl create namespace ${{ env.NAMESPACE }} --dry-run=client -o json | kubectl apply -f -
 
       - name: aks apply object
         uses: Azure/k8s-deploy@v1.4
@@ -61,3 +61,4 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: ${{ github.repository }}가 ${{ env.NAMESPACE }} 환경에 배포되었습니다 🚀

--- a/.github/workflows/aks-test-deploy.yaml
+++ b/.github/workflows/aks-test-deploy.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: create namespace
         run: |
-          kubectl create namespace ${{ env.NAMESPACE }} --dry-run -o json | kubectl apply -f -
+          kubectl create namespace ${{ env.NAMESPACE }} --dry-run=client -o json | kubectl apply -f -
 
       - name: aks apply object
         uses: Azure/k8s-deploy@v1.4
@@ -63,3 +63,4 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: ${{ github.repository }}가 ${{ env.NAMESPACE }} 환경에 배포되었습니다 🚀

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -64,32 +64,6 @@ var doc = `{
                 }
             }
         },
-        "/env": {
-            "get": {
-                "description": "앱의 환경변수를 응답합니다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "App"
-                ],
-                "summary": "앱 환경 변수",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/ping": {
             "get": {
                 "description": "server의 헬스를 체크합니다.",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -44,32 +44,6 @@
                 }
             }
         },
-        "/env": {
-            "get": {
-                "description": "앱의 환경변수를 응답합니다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "App"
-                ],
-                "summary": "앱 환경 변수",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/ping": {
             "get": {
                 "description": "server의 헬스를 체크합니다.",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -153,23 +153,6 @@ paths:
       summary: 구성 조회
       tags:
       - App
-  /env:
-    get:
-      description: 앱의 환경변수를 응답합니다.
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              items:
-                type: string
-              type: array
-            type: array
-      summary: 앱 환경 변수
-      tags:
-      - App
   /ping:
     get:
       description: server의 헬스를 체크합니다.

--- a/internal/app/handlers/api.go
+++ b/internal/app/handlers/api.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"net/http"
-	"os"
 
 	"github.com/gin-gonic/gin"
 
@@ -36,15 +35,4 @@ func Ping(c *gin.Context) {
 func AppVersion(c *gin.Context) {
 	resData := []byte(project.AppVersion)
 	c.Data(http.StatusOK, "text/html; charset=utf-8", resData)
-}
-
-// @Summary 앱 환경 변수
-// @Description 앱의 환경변수를 응답합니다.
-// @Tags App
-// @Produce json
-// @Success 200 {array} []string
-// @Router /env [get]
-func AppEnv(c *gin.Context) {
-	resData := os.Environ()
-	c.JSON(http.StatusOK, resData)
 }

--- a/internal/app/routers/router.go
+++ b/internal/app/routers/router.go
@@ -10,7 +10,7 @@ func Use(api *gin.RouterGroup) {
 	api.GET("/", handlers.AppName)
 	api.GET("/ping", handlers.Ping)
 	api.GET("/version", handlers.AppVersion)
-	api.GET("/env", handlers.AppEnv)
+
 	users := api.Group("/users")
 	{
 		users.POST("/login", handlers.UserLogin)
@@ -27,6 +27,7 @@ func Use(api *gin.RouterGroup) {
 		users.POST("/avatar", middlewares.TokenAuthMiddleware(), handlers.UploadAvatar)
 		users.DELETE("/avatar", middlewares.TokenAuthMiddleware(), handlers.DeleteAvatar)
 	}
+
 	configs := api.Group("/configs")
 	{
 		configs.GET("", handlers.GetConfigs)

--- a/internal/pkg/project/project.go
+++ b/internal/pkg/project/project.go
@@ -2,5 +2,5 @@ package project
 
 const (
 	AppName    string = "oauth-server"
-	AppVersion string = "0.5.0"
+	AppVersion string = "0.6.0"
 )

--- a/internal/pkg/project/project.go
+++ b/internal/pkg/project/project.go
@@ -2,5 +2,5 @@ package project
 
 const (
 	AppName    string = "oauth-server"
-	AppVersion string = "0.6.0"
+	AppVersion string = "1.0.0"
 )


### PR DESCRIPTION
# Fix

1. deprecated된 kubectl 명령어로 인하여 ci/cd가 오류가 발생하는 것을 해결합니다.
2. ci/cd 완료시 어떤 서비스가 어떤 환경으로 배포되었는지 알 수 있도록 개선합니다.